### PR TITLE
Use the SciJava fork of Java 3D 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>sc.fiji</groupId>
 		<artifactId>pom-fiji</artifactId>
-		<version>16.1.0</version>
+		<version>18.1.0</version>
 		<relativePath />
 	</parent>
 
@@ -136,11 +136,13 @@
 		<dependency>
 			<groupId>java3d</groupId>
 			<artifactId>j3d-core</artifactId>
+			<version>1.5.2</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>java3d</groupId>
 			<artifactId>j3d-core-utils</artifactId>
+			<version>1.5.2</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -73,17 +73,26 @@
 		</repository>
 	</repositories>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>sc.fiji</groupId>
+				<artifactId>pom-bigdataviewer</artifactId>
+				<version>${pom-bigdataviewer.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 	<dependencies>
 		<!-- BigDataViewer dependencies -->
 		<dependency>
 			<groupId>sc.fiji</groupId>
 			<artifactId>spim_data</artifactId>
-			<version>2.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>sc.fiji</groupId>
 			<artifactId>bigdataviewer-core</artifactId>
-			<version>2.0.0</version>
 		</dependency>
 
 		<!-- Fiji dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
 
 	<artifactId>MaMuT_</artifactId>
 	<version>0.17.2-SNAPSHOT</version>
+
 	<name>plugins/MaMuT_.jar</name>
 	<description></description>
 
@@ -153,5 +154,4 @@
 			<artifactId>jdom2</artifactId>
 		</dependency>
 	</dependencies>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,10 @@
 		<tag>HEAD</tag>
 		<url>https://github.com/fiji/MaMuT</url>
 	</scm>
+	<issueManagement>
+		<system>GitHub Issues</system>
+		<url>https://github.com/fiji/MaMuT/issues</url>
+	</issueManagement>
 	<ciManagement>
 		<system>Jenkins</system>
 		<url>http://jenkins.imagej.net/job/MaMuT/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
 	<properties>
 		<!-- Target Fiji dir for clean upload. -->
 		<imagej.app.directory>../Fiji.app/</imagej.app.directory>
+		<scijava.jvm.version>1.7</scijava.jvm.version>
 	</properties>
 
 	<repositories>
@@ -134,16 +135,12 @@
 
 		<!-- Java 3D dependencies -->
 		<dependency>
-			<groupId>java3d</groupId>
-			<artifactId>j3d-core</artifactId>
-			<version>1.5.2</version>
-			<scope>provided</scope>
+			<groupId>org.scijava</groupId>
+			<artifactId>j3dcore</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>java3d</groupId>
-			<artifactId>j3d-core-utils</artifactId>
-			<version>1.5.2</version>
-			<scope>provided</scope>
+			<groupId>org.scijava</groupId>
+			<artifactId>j3dutils</artifactId>
 		</dependency>
 
 		<!-- Third party dependencies -->

--- a/src/main/java/fiji/plugin/mamut/util/SourceSpotImageUpdater.java
+++ b/src/main/java/fiji/plugin/mamut/util/SourceSpotImageUpdater.java
@@ -53,7 +53,7 @@ public class SourceSpotImageUpdater<T extends RealType<T>> extends SpotImageUpda
 	 * group calls to this method for spots that belong to the same frame.
 	 */
 	@Override
-	public String getImageString(final Spot spot) {
+	public String getImageString(final Spot spot, final double radiusFactor) {
 		final StringBuffer str = new StringBuffer();
 
 		final Thread th = new Thread(threadGroup, "Spot Image grabber for " + spot) {


### PR DESCRIPTION
This means we no longer need users to install a Java 3D into their Java runtimes—we can just ship Java 3D with Fiji!

See:
* [scijava/java3d-core](https://github.com/scijava/java3d-core)
* [scijava/java3d-utils](https://github.com/scijava/java3d-utils)

Note that this version of Java 3D requires Java 7, so MaMuT will now require Java 7 by extension.