### PR TITLE
Update JGraphT to v1.3.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>23.1.1</version>
+		<version>25.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -193,8 +193,8 @@
 
 		<!-- Third party dependencies -->
 		<dependency>
-			<groupId>net.sf.jgrapht</groupId>
-			<artifactId>jgrapht</artifactId>
+			<groupId>org.jgrapht</groupId>
+			<artifactId>jgrapht-core</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.jdom</groupId>


### PR DESCRIPTION
This PR traces the actions to take to update JGraphT to v1.3.0
All projects depending on TrackMate are affected.