### PR TITLE
Update TGMMImporter2.java

### DIFF
--- a/src/main/java/fiji/plugin/mamut/ImportTGMMAnnotationPlugin_.java
+++ b/src/main/java/fiji/plugin/mamut/ImportTGMMAnnotationPlugin_.java
@@ -424,12 +424,13 @@ public class ImportTGMMAnnotationPlugin_ implements PlugIn
 		final SequenceDescriptionMinimal seq = spimData.getSequenceDescription();
 		final ViewRegistrations regs = spimData.getViewRegistrations();
 		final List< AffineTransform3D > transforms = new ArrayList<>( seq.getTimePoints().size() );
-		for ( final TimePoint t : seq.getTimePoints().getTimePointsOrdered() )
+		final List< TimePoint > timepoints = seq.getTimePoints().getTimePointsOrdered();
+		for ( final TimePoint t : timepoints )
 		{
 			transforms.add( regs.getViewRegistration( t.getId(), setupID ).getModel() );
 		}
 
-		final TGMMImporter2 importer = new TGMMImporter2( tgmmFolder, transforms, TGMMImporter2.DEFAULT_PATTERN, logger, interval, tFrom, tTo );
+		final TGMMImporter2 importer = new TGMMImporter2( tgmmFolder, transforms, timepoints, TGMMImporter2.DEFAULT_PATTERN, logger, interval, tFrom, tTo );
 		if ( !importer.checkInput() || !importer.process() )
 		{
 			logger.error( importer.getErrorMessage() );


### PR DESCRIPTION
TGMMImporter2::process() has at least four places where loop index integer t and integer frames[t] are confused, see proposed commit request.  The bug results in MaMuT not being able to import TGMM results series that begin on frames other than 0 -- even if user sets tFrom / tTo correctly.  Following these changes, importer works correctly with and without "crop on import."  Notably, Mastodon does not have this bug, and is able to import TGMM results starting and ending at any arbitrary time frame number.